### PR TITLE
fix: update translation keys for onboarding pages

### DIFF
--- a/app/src/screens/OnboardingPages.tsx
+++ b/app/src/screens/OnboardingPages.tsx
@@ -73,11 +73,11 @@ const guides: Array<{
   {
     image: CredentialList,
     title: 'OnboardingPages.SecondPageTitle',
-    body: 'OnboadingPages.SecondPageBody',
+    body: 'OnboardingPages.SecondPageBody',
   },
   {
     image: ScanShare,
-    title: 'OnboadingPages.ThirdPageTitle',
+    title: 'OnboardingPages.ThirdPageTitle',
     body: 'OnboardingPages.ThirdPageBody',
   },
 ]


### PR DESCRIPTION
Fix a small typo mistake in the key for second and third page in the Onboarding.