### PR TITLE
fix: font weight normal pour l'écran de biométrie

### DIFF
--- a/app/src/screens/UseBiometry.tsx
+++ b/app/src/screens/UseBiometry.tsx
@@ -150,7 +150,7 @@ const UseBiometry: React.FC = () => {
         <View style={{ marginTop: 20 }}>
           {biometryAvailable ? (
             <>
-              <Text style={TextTheme.bold}>{t('Biometry.EnabledText1')}</Text>
+              <Text style={TextTheme.normal}>{t('Biometry.EnabledText1')}</Text>
               <Text></Text>
               <Text style={TextTheme.normal}>
                 {t('Biometry.EnabledText2')}


### PR DESCRIPTION
Le texte ici en rouge ne devrait pas être en gras: 
![image](https://github.com/user-attachments/assets/c661cd9d-7bb5-46ad-8d60-d20895a8ff38)
