### PR TITLE
add visibility toggle for scan error info button

### DIFF
--- a/app/container-imp.ts
+++ b/app/container-imp.ts
@@ -71,6 +71,7 @@ const defaultConfig: BifoldConfig = {
   disableOnboardingSkip: true,
   showScanHelp: true,
   showScanButton: true,
+  showScanErrorButton: false,
   showDetailsInfo: true,
   contactDetailsOptions: {
     showConnectedTime: false,


### PR DESCRIPTION
# Summary of Changes

Added a conditional rendering mechanism for the `Scan Error Info` button. The button now only appears when the `showScanErrorInfoButton` flag is set to `true` in the configuration. This ensures better control and avoids unnecessary UI elements when not required.

# Screenshots, Videos, or Gifs

N/A

# Breaking Change Guide

N/A (No breaking changes introduced in this PR.)

# Related Issues

N/A (This is an isolated improvement, unrelated to any existing issues.)
