### PR TITLE
fix: ajout de test Id pour les événements dans Activités

### DIFF
--- a/app/src/components/EventItem.tsx
+++ b/app/src/components/EventItem.tsx
@@ -1,4 +1,5 @@
 import { GenericFn, testIdWithKey, ToastType, useStore, useTheme } from '@hyperledger/aries-bifold-core'
+import { HistoryCardType } from '@hyperledger/aries-bifold-core/App/modules/history/types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
@@ -9,6 +10,7 @@ import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIc
 import { hitSlop } from '../constants'
 import { useToast } from '../hooks/toast'
 import { BCDispatchAction, BCState } from '../store'
+import { NotificationTypeEnum } from '../types/notification-list-item'
 interface EventItemProps {
   action?: GenericFn
   handleDelete?: () => Promise<void>
@@ -19,6 +21,7 @@ interface EventItemProps {
     title?: string
     body?: string
     eventTime?: string
+    type?: HistoryCardType | NotificationTypeEnum
     image: JSX.Element
   }
   openSwipeableId: string | null
@@ -139,7 +142,7 @@ const EventItem = ({
   const body = (
     <Pressable
       accessibilityRole={'button'}
-      testID={testIdWithKey(`View${event.id}`)}
+      testID={testIdWithKey(`View${event.type}`)}
       onPress={pressAction}
       hitSlop={hitSlop}
       onLongPress={() => {

--- a/app/src/components/HistoryListItem.tsx
+++ b/app/src/components/HistoryListItem.tsx
@@ -122,6 +122,7 @@ const HistoryListItem: React.FC<Props> = ({
         title: details.title,
         body: details.body,
         eventTime: details.eventTime,
+        type: content.type,
         image: activateSelection ? (
           <CustomCheckBox selected={selected} setSelected={() => setSelected?.({ id: item.content.id ?? '' })} />
         ) : (

--- a/app/src/components/NotificationListItem.tsx
+++ b/app/src/components/NotificationListItem.tsx
@@ -32,18 +32,10 @@ import MessageImg from '../assets/img/Message.svg'
 import ProofRequestImg from '../assets/img/ProofRequest.svg'
 import RevocationImg from '../assets/img/Revocation.svg'
 import { BCDispatchAction, BCState } from '../store'
+import { NotificationTypeEnum } from '../types/notification-list-item'
 
 import CustomCheckBox from './CustomCheckBox'
 import EventItem from './EventItem'
-
-export enum NotificationTypeEnum {
-  BasicMessage = 'BasicMessage',
-  CredentialOffer = 'Offer',
-  ProofRequest = 'ProofRecord',
-  Revocation = 'Revocation',
-  Custom = 'Custom',
-  Proof = 'Proof',
-}
 
 interface NotificationListItemProps {
   notificationType: NotificationTypeEnum
@@ -362,6 +354,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
         title: details.title,
         body: details.body,
         eventTime: details.eventTime,
+        type: notificationType,
         image: activateSelection ? (
           <CustomCheckBox selected={selected} setSelected={() => setSelected?.({ id: notification.id })} />
         ) : (

--- a/app/src/screens/activities/NotificationsList.tsx
+++ b/app/src/screens/activities/NotificationsList.tsx
@@ -6,12 +6,13 @@ import { View, StyleSheet, SectionList, Text } from 'react-native'
 import Toast, { ToastShowParams } from 'react-native-toast-message'
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
 
-import NotificationListItem, { NotificationTypeEnum } from '../../components/NotificationListItem'
+import NotificationListItem from '../../components/NotificationListItem'
 import { NotificationReturnType, NotificationsInputProps, NotificationType } from '../../hooks/notifications'
 import { useToast } from '../../hooks/toast'
 import useMultiSelectActive from '../../hooks/useMultiSelectActive'
 import { BCDispatchAction, BCState, ActivityState } from '../../store'
 import { SelectedNotificationType } from '../../types/activities'
+import { NotificationTypeEnum } from '../../types/notification-list-item'
 
 const isHome = false
 const iconSize = 24

--- a/app/src/types/notification-list-item.ts
+++ b/app/src/types/notification-list-item.ts
@@ -1,0 +1,8 @@
+export enum NotificationTypeEnum {
+  BasicMessage = 'BasicMessage',
+  CredentialOffer = 'Offer',
+  ProofRequest = 'ProofRecord',
+  Revocation = 'Revocation',
+  Custom = 'Custom',
+  Proof = 'Proof',
+}


### PR DESCRIPTION
Cette PR régler un problème pour les testIDs qui étaient dynamiques par rapport à l'event ID. Pour les tests automatisés, il faut connaître le testID en avance.